### PR TITLE
Addresses blocking errors in the Bag export

### DIFF
--- a/lib/dspace.rb
+++ b/lib/dspace.rb
@@ -1,11 +1,6 @@
-
-require 'date'
-
-module DSpace
-  autoload :Item, 'dspace/item'
-  autoload :Bitstream, 'dspace/bitstream'
-  autoload :EPerson, 'dspace/eperson'
-  autoload :Collection, 'dspace/collection'
-  autoload :Connection, 'dspace/connection'
-  autoload :MetadataField, 'dspace/metadata_field'
-end
+require_relative 'dspace/item'
+require_relative 'dspace/bitstream'
+require_relative 'dspace/eperson'
+require_relative 'dspace/collection'
+require_relative 'dspace/connection'
+require_relative 'dspace/metadata_field'

--- a/lib/dspace/item.rb
+++ b/lib/dspace/item.rb
@@ -100,9 +100,9 @@ module DSpace
         :embargo => 'http://projecthydra.org/ns/auth/acl#hasEmbargo'
       }
 
-      if crosswalk.has_key? qualifier.to_sym
+      if qualifier && crosswalk.has_key?(qualifier.to_sym)
         crosswalk[qualifier.to_sym]
-      elsif crosswalk.has_key? element.to_sym
+      elsif crosswalk.has_key?(element.to_sym)
         crosswalk[element.to_sym]
       else
         raise NotImplementedError.new "#{element}.#{qualifier} is not a supported metadata attribute"
@@ -155,7 +155,7 @@ module DSpace
       bag.add_file(File.basename(csv_path), csv_path)
 
       # Add the file(s) from the bundle
-      @bundle.each do |bitstreams|
+      @bundle.each do |bitstream|
         bag.add_file(File.basename(bitstream.file), bitstream.file)
       end
 


### PR DESCRIPTION
- Fixing the requirements for the DSpace Module (removing autoload)
- Handling for cases where Item metadata fields have Nil qualifiers
- Fixing a syntax error for the bagging of Item Bitstreams